### PR TITLE
Update build steps to work with arbitrary commits and updated submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ v1.86
 ## Build process
 
 ```sh
-git submodule init
-git pull --recurse-submodules
+git submodule update --init --recursive
 ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-mkdir build/ && cd build/
-cmake ..
-make
+mkdir -p build/ && cd build/
+cmake .. && make
 ```
 
 ## Building on macOS


### PR DESCRIPTION
Checking out a new commit or switching branches that update submodules requires
additional steps to checkout the submodules to that commit.

`git submodule update --init --recursive` takes care of that (while the current README only works for fresh clones).

The second change is that `mkdir -p` will succeed even if the directory
is already existent, thus making the whole recipe easier to just use as
copy-paste.
