### PR TITLE
add linux convention config paths

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -25,6 +25,8 @@ public:
 
     static std::string get_resource_folder();
 
+    static std::string get_linux_config_folder();
+
     static void build_logger();
 
     //


### PR DESCRIPTION
This PR allows Vector Audio to use `~/.config/vector_audio` or `$XDG_CONFIG_HOME/vector_audio` as the config directory, which is more conventional on Linux. This would be necessary if we want to install it globally on Linux (as otherwise we will have to grant access of the credentials to all users).