### PR TITLE
Only allow single application instance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(vector_audio src/main.cpp
                 src/updater.cpp
                 src/data_file_handler.cpp
                 src/modals/settings.cpp
+                src/single_instance.cpp
                 ${CMAKE_SOURCE_DIR}/extern/PlatformFolders/sago/platform_folders.cpp
                 ${APPLE_EXTRA_LIBS})
 

--- a/include/single_instance.h
+++ b/include/single_instance.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace vector_audio {
+  class SingleInstance {
+    public:
+      explicit SingleInstance();
+      ~SingleInstance();
+      bool HasRunningInstance() const;
+    private:
+      struct instance;
+      std::unique_ptr<instance> instance_;
+  };
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,10 +16,16 @@
 #include "spdlog/spdlog.h"
 #include "style.h"
 #include "updater.h"
+#include "single_instance.h"
 
 // Main code
 int main(int, char**)
 {
+    vector_audio::SingleInstance instance;
+    if(instance.HasRunningInstance()) {
+        return 0;
+    }
+
     vector_audio::configuration::build_logger();
     sf::RenderWindow window(sf::VideoMode(800, 600), "Vector Audio");
     window.setFramerateLimit(30);

--- a/src/single_instance.cpp
+++ b/src/single_instance.cpp
@@ -1,0 +1,58 @@
+#include "single_instance.h"
+
+#if defined(_WIN32)
+#include <Windows.h>
+#elif defined(__APPLE__) || defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace vector_audio {
+
+  const std::string INSTANCE_KEY = "org.vatsim.vectoraudio";
+
+  struct SingleInstance::instance {
+    // Indicates whether another instance is running.
+    bool exists = false;
+#if defined(_WIN32)
+    // Blocking mutex on Windows platforms.
+    HANDLE mutex = nullptr;
+#elif defined(__APPLE__) || defined(__linux__)
+    // Blocking file on Unix platforms.
+    int blockingFile = -1;
+#endif
+  };
+
+  SingleInstance::SingleInstance() : instance_(new instance) {
+#if defined(_WIN32)
+    instance_->mutex = CreateMutexA(NULL, FALSE, INSTANCE_KEY.c_str());
+    instance_->exists = GetLastError() == ERROR_ALREADY_EXISTS;
+#elif defined(__APPLE__) || defined(__linux__)
+    instance_->blockingFile = open(("/tmp/" + INSTANCE_KEY).c_str(), O_CREAT | O_RDWR, 0666);
+    struct flock lock {};
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_CUR;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    instance_->exists = fcntl(instance_->blockingFile, F_SETLK, &lock) < 0;
+#endif
+  }
+
+  SingleInstance::~SingleInstance() {
+#if defined(_WIN32)
+    if(instance_->mutex) {
+      CloseHandle(instance_->mutex);
+    }
+    instance_->mutex = nullptr;
+    instance_->exists = false;
+#elif defined(__linux__) || defined(__APPLE__)
+    close(instance_->blockingFile);
+    instance_->blockingFile = -1;
+    instance_->exists = false;
+#endif
+  }
+
+  bool SingleInstance::HasRunningInstance() const {
+    return instance_->exists;
+  }
+}


### PR DESCRIPTION
Implement simple mutex to only allow a single instance of VectorAudio to be opened.

Tested on Win 11, macOS 12.6 and Ubuntu 22.04.